### PR TITLE
Use Open JDK 8 for testing instead of Oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 
 addons:


### PR DESCRIPTION
The scripts that Travis CI uses are currently broken for OracleJdk9