### PR TITLE
Fix JSON related flaky tests

### DIFF
--- a/hooks/pom.xml
+++ b/hooks/pom.xml
@@ -45,11 +45,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-			<groupId>org.skyscreamer</groupId>
-			<artifactId>jsonassert</artifactId>
-			<version>1.5.0</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hooks/pom.xml
+++ b/hooks/pom.xml
@@ -44,6 +44,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/ImportHooksTest.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/ImportHooksTest.groovy
@@ -15,7 +15,9 @@
  */
 package com.okta.hooks.sdk
 
+import org.json.JSONException
 import org.testng.annotations.Test
+import org.skyscreamer.jsonassert.JSONAssert
 
 import static com.okta.hooks.sdk.commands.UserImportCommand.createUser
 import static com.okta.hooks.sdk.commands.UserImportCommand.linkUser
@@ -25,7 +27,16 @@ import static com.okta.hooks.sdk.commands.UserImportCommand.addProfileProperties
 import static com.okta.hooks.sdk.commands.PasswordImportCommand.unverified
 import static com.okta.hooks.sdk.commands.PasswordImportCommand.verified
 
+
 class ImportHooksTest implements HooksSupport {
+
+    void assertJsonEqualsNonStrict(def actual, def expected) {
+        try {
+            JSONAssert.assertEquals(expected, actual, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
 
     @Test
     void updateUserProfile() {
@@ -47,7 +58,7 @@ class ImportHooksTest implements HooksSupport {
             }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -66,7 +77,7 @@ class ImportHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -90,7 +101,7 @@ class ImportHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -108,7 +119,7 @@ class ImportHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -126,6 +137,6 @@ class ImportHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 }


### PR DESCRIPTION
## Description
The tests under module
```
com.okta.hooks.sdk.ImportHooksTest
```
failed under environment [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detect flakiness under non-deterministic data structure usages. 

The potential problem is that `build.toString()` utilize `jackson.databind`, which internally calls `getDeclaredFields` to retrieve the data fields. There are many discussions around the topic. 

**Quote from [Oracle Java 8 Doc](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields)**
> The elements in the returned array are not sorted and are not in any particular order.

Basically, it is not guaranteed for `getDeclaredFields` to return a consistent order in different environment setup. 

Some JSON libraries (eg: avro) address this issue with an extra step of [sorting the fields](https://github.com/apache/avro/blob/release-1.10.0/lang/java/avro/src/main/java/org/apache/avro/reflect/ReflectData.java#L844). Currently, I do not see a similar implementation in `jackson.databind`.


## Reproduce
```sh
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -pl hooks -Dtest=com.okta.hooks.sdk.ImportHooksTest \
    -DnondexSeeds=1016066 #optional
```

## Proposal
There are some libraries that can check JSON string without enforcing the order. Meanwhile please let me know whether you have a better idea or if you have any concern!