### PR TITLE
fix: addressing indeterminate orderings in all tests

### DIFF
--- a/hooks/src/test/groovy/com/okta/hooks/sdk/HooksSupport.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/HooksSupport.groovy
@@ -15,7 +15,20 @@
  */
 package com.okta.hooks.sdk
 
+import org.json.JSONException
+import org.testng.annotations.Test
+import org.skyscreamer.jsonassert.JSONAssert
+
 trait HooksSupport {
+
+    void assertJsonEqualsNonStrict(def actual, def expected) {
+        try {
+            JSONAssert.assertEquals(expected, actual, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
+
 
     String expected(String jsonString) {
         return jsonString.replaceAll("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*\$)", "")

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/HooksSupport.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/HooksSupport.groovy
@@ -16,7 +16,6 @@
 package com.okta.hooks.sdk
 
 import org.json.JSONException
-import org.testng.annotations.Test
 import org.skyscreamer.jsonassert.JSONAssert
 
 trait HooksSupport {
@@ -28,7 +27,6 @@ trait HooksSupport {
             throw new IllegalArgumentException(jse.getMessage());
         }
     }
-
 
     String expected(String jsonString) {
         return jsonString.replaceAll("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*\$)", "")

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/ImportHooksTest.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/ImportHooksTest.groovy
@@ -15,9 +15,7 @@
  */
 package com.okta.hooks.sdk
 
-import org.json.JSONException
 import org.testng.annotations.Test
-import org.skyscreamer.jsonassert.JSONAssert
 
 import static com.okta.hooks.sdk.commands.UserImportCommand.createUser
 import static com.okta.hooks.sdk.commands.UserImportCommand.linkUser
@@ -29,14 +27,6 @@ import static com.okta.hooks.sdk.commands.PasswordImportCommand.verified
 
 
 class ImportHooksTest implements HooksSupport {
-
-    void assertJsonEqualsNonStrict(def actual, def expected) {
-        try {
-            JSONAssert.assertEquals(expected, actual, false);
-        } catch (JSONException jse) {
-            throw new IllegalArgumentException(jse.getMessage());
-        }
-    }
 
     @Test
     void updateUserProfile() {

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/SamlHooksTest.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/SamlHooksTest.groovy
@@ -43,7 +43,7 @@ class SamlHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -66,7 +66,7 @@ class SamlHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -105,7 +105,7 @@ class SamlHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -172,6 +172,6 @@ class SamlHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 }

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/TokenHooksTest.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/TokenHooksTest.groovy
@@ -79,7 +79,7 @@ class TokenHooksTest implements HooksSupport {
           ]
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -142,7 +142,7 @@ class TokenHooksTest implements HooksSupport {
           ]
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -184,7 +184,7 @@ class TokenHooksTest implements HooksSupport {
           ]
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -247,7 +247,7 @@ class TokenHooksTest implements HooksSupport {
           ]
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -279,6 +279,6 @@ class TokenHooksTest implements HooksSupport {
           ]
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 }

--- a/hooks/src/test/groovy/com/okta/hooks/sdk/UserRegHooksTest.groovy
+++ b/hooks/src/test/groovy/com/okta/hooks/sdk/UserRegHooksTest.groovy
@@ -44,7 +44,7 @@ class UserRegHooksTest implements HooksSupport {
             .debugContext(["foo": "bar", "one": "two"])
 
         def expectedToString = expected"""{"error": {"errorCauses": [{ "errorSummary": "test-error" }]}, "debugContext": {"foo": "bar", "one": "two"}}"""
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -86,7 +86,7 @@ class UserRegHooksTest implements HooksSupport {
            }
         }
         """
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -97,7 +97,7 @@ class UserRegHooksTest implements HooksSupport {
             .errorCause("test-error2")
 
         def expectedToString = expected"""{"error": {"errorCauses": [{ "errorSummary": "test-error1" },{ "errorSummary": "test-error2" }]}}"""
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -117,7 +117,7 @@ class UserRegHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -137,7 +137,7 @@ class UserRegHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 
     @Test
@@ -163,6 +163,6 @@ class UserRegHooksTest implements HooksSupport {
         }
         """
 
-        assertThat builder.toString(), is(expectedToString)
+        assertJsonEqualsNonStrict builder.toString(), expectedToString
     }
 }


### PR DESCRIPTION
**Description**
14 more flaky tests are found using Nondex when running commands 
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex ``` under the root directory.
Similar to the previous pull request, the reason for test flakiness is that `build.toString()` eventually calls `getDeclaredFields`, causing indeterminate orderings.

**Fixes**
Extract `assertJsonEqualsNonStrict()` as a common method for trait `HooksSupport` and have all tests including possible order permutations call the function instead for comparison.