### PR TITLE
cve fix: bump `google-auto` dep from `1.0-rc6` to `1.1.1`

### DIFF
--- a/hooks/pom.xml
+++ b/hooks/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
-            <version>1.0-rc6</version>
+            <version>1.1.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes OKTA-608981

This would in turn bring in `com.google.guava:guava:jar:32.0.1-jre` (was `com.google.guava:guava@27.0.1-jre` earlier).