### PR TITLE
cve fix: bump `testng` from `7.5.0` to `7.5.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.7.0</version>
+                <version>7.5.1</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>${testng.version}</version>
+                <version>7.7.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
OKTA-643737